### PR TITLE
Correct safari and firefox failing to bind the authHandler

### DIFF
--- a/auth-ajax.html
+++ b/auth-ajax.html
@@ -50,12 +50,13 @@ the `auth-store` (via `Polymer.AuthTokenStoreBehavior`).
         /** Whether an auth token is required to even attempt the request */
         authRequired: {
           type: Boolean,
-          value: false
+          value: false,
+          observer: 'authRequiredChanged'
         }
       },
 
-      attached: function() {
-        this._authHandlerBound = this._authHandler.bind(this);
+      authRequiredChanged: function(authRequired) {
+        if(authRequired) this._authHandlerBound = this._authHandler.bind(this);
       },
 
       // override the iron-ajax method to create options


### PR DESCRIPTION
authHandler was not being triggered in safari and firefox