### PR TITLE
Handler not triggered

### DIFF
--- a/auth-ajax.html
+++ b/auth-ajax.html
@@ -50,13 +50,12 @@ the `auth-store` (via `Polymer.AuthTokenStoreBehavior`).
         /** Whether an auth token is required to even attempt the request */
         authRequired: {
           type: Boolean,
-          value: false,
-          observer: 'authRequiredChanged'
+          value: false
         }
       },
 
-      authRequiredChanged: function(authRequired) {
-        if(authRequired) this._authHandlerBound = this._authHandler.bind(this);
+      attached: function() {
+        this._authHandlerBound = this._authHandler.bind(this);
       },
 
       // override the iron-ajax method to create options

--- a/auth-ajax.html
+++ b/auth-ajax.html
@@ -50,12 +50,13 @@ the `auth-store` (via `Polymer.AuthTokenStoreBehavior`).
         /** Whether an auth token is required to even attempt the request */
         authRequired: {
           type: Boolean,
-          value: false
+          value: false,
+          observer: 'authRequiredChanged'
         }
       },
 
-      attached: function() {
-        this._authHandlerBound = this._authHandler.bind(this);
+      authRequiredChanged: function(authRequired) {
+        if(authRequired) this._authHandlerBound = this._authHandler.bind(this);
       },
 
       // override the iron-ajax method to create options


### PR DESCRIPTION
Safari and Firefox where not adding the Authorization headers to requests, the attached appears to be running a little early for them, adding the authHandler to the authRequired property fixes this issue.